### PR TITLE
Modifies the ID to use binary_id

### DIFF
--- a/priv/repo/migrations/20150907203213_create_post.exs
+++ b/priv/repo/migrations/20150907203213_create_post.exs
@@ -1,13 +1,18 @@
 defmodule BlogPhoenix.Repo.Migrations.CreatePost do
   use Ecto.Migration
 
-  def change do
-    create table(:posts) do
+  def up do
+    create table(:posts, primary_key: false) do
+      add :id, :uuid, primary_key: true
       add :title, :string
       add :slug, :string
       add :body, :string
 
       timestamps
     end
+  end
+
+  def down do
+    drop table(:posts)
   end
 end

--- a/scripts/container/startup.sh
+++ b/scripts/container/startup.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-./scripts/container/test.sh
+mix mix ecto.migrate
 mix phoenix.server

--- a/test/models/post_test.exs
+++ b/test/models/post_test.exs
@@ -23,4 +23,10 @@ defmodule BlogPhoenix.PostTest do
     {message, _length} = changeset.errors[:title]
     assert message == "should be at least 2 characters"
   end
+
+  test "uses a UUID" do
+    changeset = Post.changeset(%Post{}, @valid_attrs)
+    {:ok, record} = Repo.insert(changeset)
+    assert String.length(record.id) == 36
+
 end

--- a/web/models/post.ex
+++ b/web/models/post.ex
@@ -1,5 +1,6 @@
 defmodule BlogPhoenix.Post do
   use BlogPhoenix.Web, :model
+  use BlogPhoenix.Schema
 
   schema "posts" do
     field :title, :string

--- a/web/models/schema.ex
+++ b/web/models/schema.ex
@@ -1,0 +1,10 @@
+defmodule BlogPhoenix.Schema do
+   defmacro __using__(_) do
+     quote do
+       use Ecto.Schema
+       @primary_key {:id, :binary_id, autogenerate: true}
+       @foreign_key_type :binary_id
+     end
+   end
+end
+


### PR DESCRIPTION
This uses uuid in the migration that creates the post
This autogenerates a UUID for each post
Resolves #30