### PR TITLE
Removes the stopping of running containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,15 @@ run:
 	docker-compose start db
 	docker run -it --rm --name blog -p 80\:4000 --link blogphoenix_db_1\:db dmitrinesterenko/blog\:latest
 
+push:
+	 docker push dmitrinesterenko/blog\:latest
+
 deploy:
-	docker push dmitrinesterenko/blog\:latest
-#        use
+	#        use
 	docker pull dmitrinesterenko/blog\:latest
-	docker ps -q -f "name=blog" | xargs docker stop | xargs docker rm
+	#docker ps -q -f "name=blog" | xargs docker stop | xargs docker rm
 	docker-compose -f docker-compose-development.yml start db
-	docker run -d --rm -p 80\:4000 --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest
+	docker run -d -p 80\:4000 --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest
 
 shell:
 	docker run -it --rm -p 80\:4000 --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest /bin/bash


### PR DESCRIPTION
It's dangerous to match on a wide parameter like "blog" as it stops the database
as well.

Move push into a separate step as it comes before switching to the remote
machine.

Clarifies the use of -d in place of --rm which is still biting my ass.