### PR TITLE
Configure production host and container options

### DIFF
--- a/Dockerfile-production
+++ b/Dockerfile-production
@@ -1,10 +1,11 @@
 FROM dmitrinesterenko/blogbase:latest
 
 #TODO this is not necessary once you use docker-compose
+ENV ENVIRONMENT prod
 ENV WORKDIR /webapp/current
 RUN mkdir -p $WORKDIR
 WORKDIR $WORKDIR
 COPY . $WORKDIR
-RUN mix compile
+RUN MIX_ENV=$ENVIRONMENT mix compile
 EXPOSE 4000
 CMD ["./scripts/container/startup.sh"]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ deploy:
 	docker pull dmitrinesterenko/blog\:latest
 	#docker ps -q -f "name=blog" | xargs docker stop | xargs docker rm
 	docker-compose -f docker-compose-development.yml start db
-	docker run -d -p 80\:4000 --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest
+	docker run -d -p 80\:4000 -e "PORT=4000" -e "MIX_ENV=prod" --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest
 
 shell:
 	docker run -it --rm -p 80\:4000 --link blogphoenix_db_1:db --name blog dmitrinesterenko/blog\:latest /bin/bash

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,8 +13,10 @@ use Mix.Config
 # which you typically run after static files are built.
 config :blog_phoenix, BlogPhoenix.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: "example.com"],
+  debug_errors: true,
+  url: [host: "dmitri.co"],
   cache_static_manifest: "priv/static/manifest.json"
+
 
 # ## SSL Support
 #
@@ -38,7 +40,7 @@ config :logger, level: :info
 # If you are doing OTP releases, you need to instruct Phoenix
 # to start the server for all endpoints:
 #
-#     config :phoenix, :serve_endpoints, true
+config :phoenix, :serve_endpoints, true
 #
 # Alternatively, you can configure exactly which server to
 # start per endpoint:


### PR DESCRIPTION
Fix socket transport by configuring production
Passes environment variables for port and env when starting up the container.

[Finishes #47]